### PR TITLE
Fix factual errors in dataset help files

### DIFF
--- a/R/AirPassengersDf.R
+++ b/R/AirPassengersDf.R
@@ -6,7 +6,7 @@
 #'@name AirPassengersDf
 #'@docType data
 #'@usage data("AirPassengersDf")
-#'@format A data frame with 142 rows and 2 columns (Month and Passengers).
+#'@format A data frame with 144 rows and 2 columns (Month and Passengers).
 #' @examples
 #' data("AirPassengersDf")
 #' head(AirPassengersDf)

--- a/R/depression.R
+++ b/R/depression.R
@@ -2,17 +2,17 @@
 #'
 #'@description
 #'  The data correspond to an experiment in which a treatment for depression is
-#'  studied. Two groups of patients (1: control / 2: treatment) have been
-#'  followed at five different times (0: pre-test, 1: one month post-test, 3: 3
-#'  months follow-up and 6: 6 months follow-up). The dependent variable is a
-#'  depression score.
+#'  studied. Two groups of patients - control ("ctr") and treatment
+#'  ("treated") - have been followed at four different time points: t0
+#'  (pre-test) and three post-test follow-up measurements (t1, t2, t3). The
+#'  dependent variable is a depression score.
 #'
 #'  Repeated measures ANOVA can be performed in order to determine the effect
 #'  of the treatment and the effect of time on the depression score.
 #'@name depression
 #'@docType data
 #'@usage data("depression")
-#'@format A data frame with 24 rows and 5 columns.
+#'@format A data frame with 24 rows and 6 columns.
 #' @examples
 #' data(depression)
 #' head(as.data.frame(depression))

--- a/R/headache.R
+++ b/R/headache.R
@@ -1,11 +1,6 @@
 #'Headache Data for Three Way ANOVA
 #'
-#'@description Measures of cholesterol concentration in 72 participants treated
-#'  with three different drugs. The aim is to examine the potential of new class
-#'  of drugs in lowering the cholesterol concentration and consequently reducing
-#'  heart attack.
-#'
-#'  A pharmaceutical company tested three treatments for migraine headache
+#'@description A pharmaceutical company tested three treatments for migraine headache
 #'  sufferers. 72 participants were enrolled in the experiments. The aim is to
 #'  examine the potential of new class of treatments in lowering the pain score
 #'  associated with the migraine headache episode.
@@ -16,13 +11,15 @@
 #'
 #'  This data set is suited for three way Anova test.
 #'
-#'  It contain the following variables: \itemize{ \item gender, which has two
-#'  categories: "male" and "female"; \item risk which has two levels: "low" and
-#'  "high" \item treatment, which has three categories: "X", "Y" and "Z". }
+#'  It contain the following variables: \itemize{ \item id, the participant
+#'  identifier; \item gender, which has two categories: "male" and "female";
+#'  \item risk, which has two levels: "low" and "high"; \item treatment, which
+#'  has three categories: "X", "Y" and "Z"; \item pain_score, the outcome (pain
+#'  score associated with the migraine headache episode). }
 #'@name headache
 #'@docType data
 #'@usage data("headache")
-#'@format A data frame with 72 rows and 4 columns.
+#'@format A data frame with 72 rows and 5 columns.
 #' @examples
 #' data(headache)
 #' head(as.data.frame(headache))

--- a/R/heartattack.R
+++ b/R/heartattack.R
@@ -11,11 +11,11 @@
 #'
 #'  This data set is suited for three way Anova test.
 #'
-#'  It contain the following variables: \itemize{ \item gender, which has two
-#'  categories: "male" and "female"; \item risk which has two levels: "low" and
-#'  "high"
-#'  \item drug, which has three categories: "A", "B" and "C".
-#'  }
+#'  It contain the following variables: \itemize{ \item id, the participant
+#'  identifier; \item gender, which has two categories: "male" and "female";
+#'  \item risk, which has two levels: "low" and "high"; \item drug, which has
+#'  three categories: "A", "B" and "C"; \item cholesterol, the outcome
+#'  (cholesterol concentration). }
 #'@name heartattack
 #'@docType data
 #'@usage data("heartattack")

--- a/R/jobsatisfaction.R
+++ b/R/jobsatisfaction.R
@@ -5,7 +5,7 @@
 #'@name jobsatisfaction
 #'@docType data
 #'@usage data("jobsatisfaction")
-#'@format A data frame with 58 rows and 3 columns.
+#'@format A data frame with 58 rows and 4 columns.
 #' @examples
 #' data(jobsatisfaction)
 #' head(as.data.frame(jobsatisfaction))

--- a/R/performance.R
+++ b/R/performance.R
@@ -10,7 +10,7 @@
 #'@name performance
 #'@docType data
 #'@usage data("performance")
-#'@format A data frame with 24 rows and 5 columns.
+#'@format A data frame with 60 rows and 5 columns.
 #' @examples
 #' data(performance)
 #' head(as.data.frame(performance))

--- a/R/weightloss.R
+++ b/R/weightloss.R
@@ -1,7 +1,7 @@
 #'Weight Loss Score Data for Three-way Repeated Measures ANOVA
 #'
 #'@description A researcher wanted to assess the effects of Diet and Exercises
-#'  on weight loss in 10 sedentary males.
+#'  on weight loss in 12 sedentary males.
 #'
 #'  The participants were enrolled in four trials: (1) no diet and no exercises;
 #'  (2) diet only; (3) exercises only; and (4) diet and exercises combined.

--- a/man/AirPassengersDf.Rd
+++ b/man/AirPassengersDf.Rd
@@ -5,7 +5,7 @@
 \alias{AirPassengersDf}
 \title{Air Passengers}
 \format{
-A data frame with 142 rows and 2 columns (Month and Passengers).
+A data frame with 144 rows and 2 columns (Month and Passengers).
 }
 \usage{
 data("AirPassengersDf")

--- a/man/depression.Rd
+++ b/man/depression.Rd
@@ -5,17 +5,17 @@
 \alias{depression}
 \title{Depression Data for Two Way Mixed ANOVA}
 \format{
-A data frame with 24 rows and 5 columns.
+A data frame with 24 rows and 6 columns.
 }
 \usage{
 data("depression")
 }
 \description{
 The data correspond to an experiment in which a treatment for depression is
- studied. Two groups of patients (1: control / 2: treatment) have been
- followed at five different times (0: pre-test, 1: one month post-test, 3: 3
- months follow-up and 6: 6 months follow-up). The dependent variable is a
- depression score.
+ studied. Two groups of patients - control ("ctr") and treatment
+ ("treated") - have been followed at four different time points: t0
+ (pre-test) and three post-test follow-up measurements (t1, t2, t3). The
+ dependent variable is a depression score.
 
  Repeated measures ANOVA can be performed in order to determine the effect
  of the treatment and the effect of time on the depression score.

--- a/man/headache.Rd
+++ b/man/headache.Rd
@@ -5,18 +5,13 @@
 \alias{headache}
 \title{Headache Data for Three Way ANOVA}
 \format{
-A data frame with 72 rows and 4 columns.
+A data frame with 72 rows and 5 columns.
 }
 \usage{
 data("headache")
 }
 \description{
-Measures of cholesterol concentration in 72 participants treated
- with three different drugs. The aim is to examine the potential of new class
- of drugs in lowering the cholesterol concentration and consequently reducing
- heart attack.
-
- A pharmaceutical company tested three treatments for migraine headache
+A pharmaceutical company tested three treatments for migraine headache
  sufferers. 72 participants were enrolled in the experiments. The aim is to
  examine the potential of new class of treatments in lowering the pain score
  associated with the migraine headache episode.
@@ -27,9 +22,11 @@ Measures of cholesterol concentration in 72 participants treated
 
  This data set is suited for three way Anova test.
 
- It contain the following variables: \itemize{ \item gender, which has two
- categories: "male" and "female"; \item risk which has two levels: "low" and
- "high" \item treatment, which has three categories: "X", "Y" and "Z". }
+ It contain the following variables: \itemize{ \item id, the participant
+ identifier; \item gender, which has two categories: "male" and "female";
+ \item risk, which has two levels: "low" and "high"; \item treatment, which
+ has three categories: "X", "Y" and "Z"; \item pain_score, the outcome (pain
+ score associated with the migraine headache episode). }
 }
 \examples{
 data(headache)

--- a/man/heartattack.Rd
+++ b/man/heartattack.Rd
@@ -22,11 +22,11 @@ Measures of cholesterol concentration in 72 participants treated
 
  This data set is suited for three way Anova test.
 
- It contain the following variables: \itemize{ \item gender, which has two
- categories: "male" and "female"; \item risk which has two levels: "low" and
- "high"
- \item drug, which has three categories: "A", "B" and "C".
- }
+ It contain the following variables: \itemize{ \item id, the participant
+ identifier; \item gender, which has two categories: "male" and "female";
+ \item risk, which has two levels: "low" and "high"; \item drug, which has
+ three categories: "A", "B" and "C"; \item cholesterol, the outcome
+ (cholesterol concentration). }
 }
 \examples{
 data(heartattack)

--- a/man/jobsatisfaction.Rd
+++ b/man/jobsatisfaction.Rd
@@ -5,7 +5,7 @@
 \alias{jobsatisfaction}
 \title{Job Satisfaction Data for Two-Way ANOVA}
 \format{
-A data frame with 58 rows and 3 columns.
+A data frame with 58 rows and 4 columns.
 }
 \usage{
 data("jobsatisfaction")

--- a/man/performance.Rd
+++ b/man/performance.Rd
@@ -5,7 +5,7 @@
 \alias{performance}
 \title{Performance Data for Three-Way Mixed ANOVA}
 \format{
-A data frame with 24 rows and 5 columns.
+A data frame with 60 rows and 5 columns.
 }
 \usage{
 data("performance")

--- a/man/weightloss.Rd
+++ b/man/weightloss.Rd
@@ -12,7 +12,7 @@ data("weightloss")
 }
 \description{
 A researcher wanted to assess the effects of Diet and Exercises
- on weight loss in 10 sedentary males.
+ on weight loss in 12 sedentary males.
 
  The participants were enrolled in four trials: (1) no diet and no exercises;
  (2) diet only; (3) exercises only; and (4) diet and exercises combined.


### PR DESCRIPTION
Corrects factual errors in seven dataset help files. Documentation only — no
dataset is modified; every `data/*.rda` is byte-identical, and each corrected
statement was checked against the actual object.

- `AirPassengersDf`: `@format` 142 -> 144 rows.
- `depression`: `@format` 5 -> 6 columns; the two treatment groups are now
  described by their real factor levels ("ctr"/"treated") and the four time
  points t0-t3 (the previous text said "five different times" and gave a month
  mapping that did not match the columns).
- `headache`: `@format` 4 -> 5 columns; removed a paragraph about cholesterol
  and heart attack that had been pasted in from `heartattack`; added the
  omitted `id` and `pain_score` to the variable list.
- `heartattack`: added the omitted `id` and `cholesterol` to the variable list.
- `jobsatisfaction`: `@format` 3 -> 4 columns.
- `performance`: `@format` 24 -> 60 rows.
- `weightloss`: 10 -> 12 sedentary males (the data has 12 participant ids).

Verified: all 21 `data/*.rda` byte-identical; every `@format` dimension now
matches `dim()`; `tools::checkRd()` clean; `R CMD check --as-cran` reports no
errors or warnings. `man/*.Rd` reproduced exactly by `devtools::document()`
(roxygen2 7.3.1).

Note: the `R-CMD-check` workflow triggers on `master`, but the default branch
is `main`, so it does not run on this PR. A separate change will update the
trigger to `main` so CI runs again.
