### PR TITLE
Remove the retired CRAN checks badge from the README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,6 @@ knitr::opts_chunk$set(
 
 [![R build status](https://github.com/kassambara/datarium/workflows/R-CMD-check/badge.svg)](https://github.com/kassambara/datarium/actions)
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/datarium)](https://cran.r-project.org/package=datarium)
-[![CRAN Checks](https://cranchecks.info/badges/summary/datarium)](https://cran.r-project.org/web/checks/check_results_datarium.html)
 [![Downloads](https://cranlogs.r-pkg.org/badges/datarium)](https://cran.r-project.org/package=datarium)
 [![Total Downloads](https://cranlogs.r-pkg.org/badges/grand-total/datarium?color=orange)](https://cranlogs.r-pkg.org/badges/grand-total/datarium)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![R build
 status](https://github.com/kassambara/datarium/workflows/R-CMD-check/badge.svg)](https://github.com/kassambara/datarium/actions)
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/datarium)](https://cran.r-project.org/package=datarium)
-[![CRAN
-Checks](https://cranchecks.info/badges/summary/datarium)](https://cran.r-project.org/web/checks/check_results_datarium.html)
 [![Downloads](https://cranlogs.r-pkg.org/badges/datarium)](https://cran.r-project.org/package=datarium)
 [![Total
 Downloads](https://cranlogs.r-pkg.org/badges/grand-total/datarium?color=orange)](https://cranlogs.r-pkg.org/badges/grand-total/datarium)


### PR DESCRIPTION
The cranchecks.info badge service is shutting down, so the "CRAN Checks" badge no longer resolves. Removes it from `README.Rmd` and the generated `README.md`; the other badges are unchanged. Fixes #4.