### PR TITLE
Document variables and add examples for the two-means datasets

### DIFF
--- a/R/genderweight.R
+++ b/R/genderweight.R
@@ -1,15 +1,23 @@
 #'Weight Data By Gender for Two-Samples Mean Test
 #'
 #'@description Contains the weights by sex (M for male; F for
-#'  female). The question is whether the average women’s weight differs from the
-#'  average men’s weight?
+#'  female). The question is whether the average women's weight differs from the
+#'  average men's weight?
 #'
 #'  A two-samples independent t-test can be performed to answer to this question.
 #'@name genderweight
 #'@docType data
 #'@usage data("genderweight")
-#'@format A data frame with 40 rows and 3 columns
+#'@format A data frame with 40 rows and 3 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 40).}
+#'    \item{group}{the participant's sex, "F" (female) or "M" (male).}
+#'    \item{weight}{the participant's body weight.}
+#'  }
 #' @examples
 #' data(genderweight)
-#' head(as.data.frame(genderweight))
+#' head(genderweight)
+#'
+#' # Two-samples independent t-test: do mean weights differ by sex?
+#' t.test(weight ~ group, data = genderweight)
 NULL

--- a/R/mice.R
+++ b/R/mice.R
@@ -7,8 +7,15 @@
 #'@name mice
 #'@docType data
 #'@usage data("mice")
-#'@format A data frame with 10 rows and 2 columns
+#'@format A data frame with 10 rows and 2 columns (stored as a tibble).
+#'  \describe{
+#'    \item{name}{mouse identifier, "M_1" to "M_10".}
+#'    \item{weight}{the mouse weight, in grams.}
+#'  }
 #' @examples
 #' data(mice)
-#' head(as.data.frame(mice))
+#' head(mice)
+#'
+#' # One-sample t-test: does the mean weight differ from 25 g?
+#' t.test(mice$weight, mu = 25)
 NULL

--- a/R/mice2.R
+++ b/R/mice2.R
@@ -6,8 +6,16 @@
 #'@name mice2
 #'@docType data
 #'@usage data("mice2")
-#'@format A data frame with 10 rows and 3 columns
+#'@format A data frame with 10 rows and 3 columns.
+#'  \describe{
+#'    \item{id}{mouse identifier (1 to 10).}
+#'    \item{before}{the mouse weight before the treatment.}
+#'    \item{after}{the mouse weight after the treatment.}
+#'  }
 #' @examples
 #' data(mice2)
-#' head(as.data.frame(mice2))
+#' head(mice2)
+#'
+#' # Paired-samples t-test: did the treatment change the weight?
+#' t.test(mice2$before, mice2$after, paired = TRUE)
 NULL

--- a/man/genderweight.Rd
+++ b/man/genderweight.Rd
@@ -5,19 +5,27 @@
 \alias{genderweight}
 \title{Weight Data By Gender for Two-Samples Mean Test}
 \format{
-A data frame with 40 rows and 3 columns
+A data frame with 40 rows and 3 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 40).}
+   \item{group}{the participant's sex, "F" (female) or "M" (male).}
+   \item{weight}{the participant's body weight.}
+ }
 }
 \usage{
 data("genderweight")
 }
 \description{
 Contains the weights by sex (M for male; F for
- female). The question is whether the average women’s weight differs from the
- average men’s weight?
+ female). The question is whether the average women's weight differs from the
+ average men's weight?
 
  A two-samples independent t-test can be performed to answer to this question.
 }
 \examples{
 data(genderweight)
-head(as.data.frame(genderweight))
+head(genderweight)
+
+# Two-samples independent t-test: do mean weights differ by sex?
+t.test(weight ~ group, data = genderweight)
 }

--- a/man/mice.Rd
+++ b/man/mice.Rd
@@ -5,7 +5,11 @@
 \alias{mice}
 \title{Mice Weight Data for One Sample Mean Test}
 \format{
-A data frame with 10 rows and 2 columns
+A data frame with 10 rows and 2 columns (stored as a tibble).
+ \describe{
+   \item{name}{mouse identifier, "M_1" to "M_10".}
+   \item{weight}{the mouse weight, in grams.}
+ }
 }
 \usage{
 data("mice")
@@ -18,5 +22,8 @@ A one sample t-test can be performed to answer to this question.
 }
 \examples{
 data(mice)
-head(as.data.frame(mice))
+head(mice)
+
+# One-sample t-test: does the mean weight differ from 25 g?
+t.test(mice$weight, mu = 25)
 }

--- a/man/mice2.Rd
+++ b/man/mice2.Rd
@@ -5,7 +5,12 @@
 \alias{mice2}
 \title{Mice Weight Data for Paired-Samples Mean Test}
 \format{
-A data frame with 10 rows and 3 columns
+A data frame with 10 rows and 3 columns.
+ \describe{
+   \item{id}{mouse identifier (1 to 10).}
+   \item{before}{the mouse weight before the treatment.}
+   \item{after}{the mouse weight after the treatment.}
+ }
 }
 \usage{
 data("mice2")
@@ -17,5 +22,8 @@ A paired-samples t-test can be performed to answer to this question.
 }
 \examples{
 data(mice2)
-head(as.data.frame(mice2))
+head(mice2)
+
+# Paired-samples t-test: did the treatment change the weight?
+t.test(mice2$before, mice2$after, paired = TRUE)
 }


### PR DESCRIPTION
Adds `@format \describe{}` (one entry per variable) and a canonical base-R example to `mice`, `mice2`, and `genderweight`. Documentation only — no data changed (all `data/*.rda` byte-identical); every statement is taken from the actual object.

- `mice`: one-sample `t.test(weight, mu = 25)`; weight documented in grams (the comparison value the help already references).
- `mice2`: paired `t.test(before, after)` (a plain data frame, not a tibble).
- `genderweight`: two-sample `t.test(weight ~ group)`.

Variable meanings, factor levels and the tibble wording come from the objects; units are stated only where the data/text establishes them (deferred elsewhere rather than invented). Verified: `checkRd` clean, examples run, the dataset-consistency check still passes, `data/` untouched.