### PR TITLE
Document variables and add examples for the ANOVA datasets

### DIFF
--- a/R/headache.R
+++ b/R/headache.R
@@ -10,17 +10,22 @@
 #'  migraine headache.
 #'
 #'  This data set is suited for three way Anova test.
-#'
-#'  It contain the following variables: \itemize{ \item id, the participant
-#'  identifier; \item gender, which has two categories: "male" and "female";
-#'  \item risk, which has two levels: "low" and "high"; \item treatment, which
-#'  has three categories: "X", "Y" and "Z"; \item pain_score, the outcome (pain
-#'  score associated with the migraine headache episode). }
 #'@name headache
 #'@docType data
 #'@usage data("headache")
-#'@format A data frame with 72 rows and 5 columns.
+#'@format A data frame with 72 rows and 5 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 72).}
+#'    \item{gender}{the participant's gender, "male" or "female".}
+#'    \item{risk}{the participant's migraine risk, "high" or "low".}
+#'    \item{treatment}{the treatment received, "X", "Y" or "Z".}
+#'    \item{pain_score}{a simulated migraine pain score (an arbitrary scale with
+#'      no real-world units).}
+#'  }
 #' @examples
 #' data(headache)
-#' head(as.data.frame(headache))
+#' head(headache)
+#'
+#' # Three-way ANOVA of the pain score
+#' summary(aov(pain_score ~ gender * risk * treatment, data = headache))
 NULL

--- a/R/heartattack.R
+++ b/R/heartattack.R
@@ -10,17 +10,21 @@
 #'  high risk of heart attack.
 #'
 #'  This data set is suited for three way Anova test.
-#'
-#'  It contain the following variables: \itemize{ \item id, the participant
-#'  identifier; \item gender, which has two categories: "male" and "female";
-#'  \item risk, which has two levels: "low" and "high"; \item drug, which has
-#'  three categories: "A", "B" and "C"; \item cholesterol, the outcome
-#'  (cholesterol concentration). }
 #'@name heartattack
 #'@docType data
 #'@usage data("heartattack")
-#'@format A data frame with 72 rows and 5 columns.
+#'@format A data frame with 72 rows and 5 columns (stored as a tibble).
+#'  \describe{
+#'    \item{gender}{the participant's gender, "male" or "female".}
+#'    \item{risk}{the participant's heart attack risk, "high" or "low".}
+#'    \item{drug}{the drug received, "A", "B" or "C".}
+#'    \item{cholesterol}{the blood cholesterol concentration.}
+#'    \item{id}{participant identifier (1 to 72).}
+#'  }
 #' @examples
 #' data(heartattack)
-#' head(as.data.frame(heartattack))
+#' head(heartattack)
+#'
+#' # Three-way ANOVA of the cholesterol concentration
+#' summary(aov(cholesterol ~ gender * risk * drug, data = heartattack))
 NULL

--- a/R/jobsatisfaction.R
+++ b/R/jobsatisfaction.R
@@ -5,8 +5,19 @@
 #'@name jobsatisfaction
 #'@docType data
 #'@usage data("jobsatisfaction")
-#'@format A data frame with 58 rows and 4 columns.
+#'@format A data frame with 58 rows and 4 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 58).}
+#'    \item{gender}{the participant's gender, "male" or "female".}
+#'    \item{education_level}{the participant's education level, "school",
+#'      "college" or "university".}
+#'    \item{score}{a simulated job satisfaction score (an arbitrary scale with
+#'      no real-world units).}
+#'  }
 #' @examples
 #' data(jobsatisfaction)
-#' head(as.data.frame(jobsatisfaction))
+#' head(jobsatisfaction)
+#'
+#' # Two-way ANOVA of satisfaction by gender and education level
+#' summary(aov(score ~ gender * education_level, data = jobsatisfaction))
 NULL

--- a/R/performance.R
+++ b/R/performance.R
@@ -10,8 +10,22 @@
 #'@name performance
 #'@docType data
 #'@usage data("performance")
-#'@format A data frame with 60 rows and 5 columns.
+#'@format A data frame with 60 rows and 5 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 60).}
+#'    \item{gender}{the participant's gender, "male" or "female".}
+#'    \item{stress}{the stress level, "low", "moderate" or "high".}
+#'    \item{t1}{a simulated performance score at the first time point (an
+#'      arbitrary scale with no real-world units).}
+#'    \item{t2}{the performance score at the second time point (same scale as t1).}
+#'  }
 #' @examples
 #' data(performance)
-#' head(as.data.frame(performance))
+#' head(performance)
+#'
+#' # Three-way mixed ANOVA: gender and stress (between) x time (within)
+#' perf_long <- reshape(performance, varying = c("t1", "t2"),
+#'                      v.names = "score", timevar = "time", direction = "long")
+#' summary(aov(score ~ gender * stress * factor(time) + Error(factor(id)/time),
+#'             data = perf_long))
 NULL

--- a/man/headache.Rd
+++ b/man/headache.Rd
@@ -5,7 +5,15 @@
 \alias{headache}
 \title{Headache Data for Three Way ANOVA}
 \format{
-A data frame with 72 rows and 5 columns.
+A data frame with 72 rows and 5 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 72).}
+   \item{gender}{the participant's gender, "male" or "female".}
+   \item{risk}{the participant's migraine risk, "high" or "low".}
+   \item{treatment}{the treatment received, "X", "Y" or "Z".}
+   \item{pain_score}{a simulated migraine pain score (an arbitrary scale with
+     no real-world units).}
+ }
 }
 \usage{
 data("headache")
@@ -21,14 +29,11 @@ A pharmaceutical company tested three treatments for migraine headache
  migraine headache.
 
  This data set is suited for three way Anova test.
-
- It contain the following variables: \itemize{ \item id, the participant
- identifier; \item gender, which has two categories: "male" and "female";
- \item risk, which has two levels: "low" and "high"; \item treatment, which
- has three categories: "X", "Y" and "Z"; \item pain_score, the outcome (pain
- score associated with the migraine headache episode). }
 }
 \examples{
 data(headache)
-head(as.data.frame(headache))
+head(headache)
+
+# Three-way ANOVA of the pain score
+summary(aov(pain_score ~ gender * risk * treatment, data = headache))
 }

--- a/man/heartattack.Rd
+++ b/man/heartattack.Rd
@@ -5,7 +5,14 @@
 \alias{heartattack}
 \title{Heart Attack Data for Three Way ANOVA}
 \format{
-A data frame with 72 rows and 5 columns.
+A data frame with 72 rows and 5 columns (stored as a tibble).
+ \describe{
+   \item{gender}{the participant's gender, "male" or "female".}
+   \item{risk}{the participant's heart attack risk, "high" or "low".}
+   \item{drug}{the drug received, "A", "B" or "C".}
+   \item{cholesterol}{the blood cholesterol concentration.}
+   \item{id}{participant identifier (1 to 72).}
+ }
 }
 \usage{
 data("heartattack")
@@ -21,14 +28,11 @@ Measures of cholesterol concentration in 72 participants treated
  high risk of heart attack.
 
  This data set is suited for three way Anova test.
-
- It contain the following variables: \itemize{ \item id, the participant
- identifier; \item gender, which has two categories: "male" and "female";
- \item risk, which has two levels: "low" and "high"; \item drug, which has
- three categories: "A", "B" and "C"; \item cholesterol, the outcome
- (cholesterol concentration). }
 }
 \examples{
 data(heartattack)
-head(as.data.frame(heartattack))
+head(heartattack)
+
+# Three-way ANOVA of the cholesterol concentration
+summary(aov(cholesterol ~ gender * risk * drug, data = heartattack))
 }

--- a/man/jobsatisfaction.Rd
+++ b/man/jobsatisfaction.Rd
@@ -5,7 +5,15 @@
 \alias{jobsatisfaction}
 \title{Job Satisfaction Data for Two-Way ANOVA}
 \format{
-A data frame with 58 rows and 4 columns.
+A data frame with 58 rows and 4 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 58).}
+   \item{gender}{the participant's gender, "male" or "female".}
+   \item{education_level}{the participant's education level, "school",
+     "college" or "university".}
+   \item{score}{a simulated job satisfaction score (an arbitrary scale with
+     no real-world units).}
+ }
 }
 \usage{
 data("jobsatisfaction")
@@ -15,5 +23,8 @@ Contains the job satisfaction score organized by gender and education level.
 }
 \examples{
 data(jobsatisfaction)
-head(as.data.frame(jobsatisfaction))
+head(jobsatisfaction)
+
+# Two-way ANOVA of satisfaction by gender and education level
+summary(aov(score ~ gender * education_level, data = jobsatisfaction))
 }

--- a/man/performance.Rd
+++ b/man/performance.Rd
@@ -5,7 +5,15 @@
 \alias{performance}
 \title{Performance Data for Three-Way Mixed ANOVA}
 \format{
-A data frame with 60 rows and 5 columns.
+A data frame with 60 rows and 5 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 60).}
+   \item{gender}{the participant's gender, "male" or "female".}
+   \item{stress}{the stress level, "low", "moderate" or "high".}
+   \item{t1}{a simulated performance score at the first time point (an
+     arbitrary scale with no real-world units).}
+   \item{t2}{the performance score at the second time point (same scale as t1).}
+ }
 }
 \usage{
 data("performance")
@@ -21,5 +29,11 @@ Contains the performance score measures of participants at two
 }
 \examples{
 data(performance)
-head(as.data.frame(performance))
+head(performance)
+
+# Three-way mixed ANOVA: gender and stress (between) x time (within)
+perf_long <- reshape(performance, varying = c("t1", "t2"),
+                     v.names = "score", timevar = "time", direction = "long")
+summary(aov(score ~ gender * stress * factor(time) + Error(factor(id)/time),
+            data = perf_long))
 }


### PR DESCRIPTION
Adds `@format \describe{}` and a canonical base-R ANOVA example to `jobsatisfaction`, `headache`, `heartattack`, and `performance`. Documentation only — data unchanged (byte-identical), every statement taken from the object.

- `jobsatisfaction`: two-way `aov(score ~ gender * education_level)`.
- `headache`: three-way `aov(pain_score ~ gender * risk * treatment)`.
- `heartattack`: three-way `aov(cholesterol ~ gender * risk * drug)`.
- `performance`: three-way mixed ANOVA (gender, stress between; time within) via `reshape()` + `aov(... + Error(factor(id)/time))`.

For `headache`/`heartattack` the variable list moves from the description into `@format \describe{}`. Simulated score columns (`jobsatisfaction$score`, `headache$pain_score`, `performance$t1/t2`) are documented as an arbitrary scale with no real-world units; `cholesterol` is described without an assumed unit. Verified: `checkRd` clean, examples run, dataset-consistency check passes, `data/` untouched.