### PR TITLE
Document the repeated-measures datasets (variables, source, examples)

### DIFF
--- a/R/depression.R
+++ b/R/depression.R
@@ -12,8 +12,26 @@
 #'@name depression
 #'@docType data
 #'@usage data("depression")
-#'@format A data frame with 24 rows and 6 columns.
+#'@format A data frame with 24 rows and 6 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 24).}
+#'    \item{treatment}{the treatment group, "ctr" (control) or "treated".}
+#'    \item{t0}{the depression score at pre-test.}
+#'    \item{t1}{the depression score at the first post-test follow-up.}
+#'    \item{t2}{the depression score at the second post-test follow-up.}
+#'    \item{t3}{the depression score at the third post-test follow-up.}
+#'  }
+#'  The depression score is a simulated measure on an arbitrary scale with no
+#'  real-world units.
+#'@source A simulated dataset created for teaching two-way mixed ANOVA.
 #' @examples
 #' data(depression)
-#' head(as.data.frame(depression))
+#' head(depression)
+#'
+#' # Two-way mixed ANOVA: treatment (between) x time (within)
+#' depression_long <- reshape(depression, varying = c("t0", "t1", "t2", "t3"),
+#'                            v.names = "score", timevar = "time",
+#'                            direction = "long")
+#' summary(aov(score ~ treatment * factor(time) + Error(factor(id)/factor(time)),
+#'             data = depression_long))
 NULL

--- a/R/selfesteem.R
+++ b/R/selfesteem.R
@@ -8,8 +8,24 @@
 #'@name selfesteem
 #'@docType data
 #'@usage data("selfesteem")
-#'@format A data frame with 10 rows and 4 columns.
+#'@format A data frame with 10 rows and 4 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 10).}
+#'    \item{t1}{the self-esteem score at the first time point.}
+#'    \item{t2}{the self-esteem score at the second time point.}
+#'    \item{t3}{the self-esteem score at the third time point.}
+#'  }
+#'  The self-esteem score is a simulated measure on an arbitrary scale with no
+#'  real-world units.
+#'@source A simulated dataset created for teaching one-way repeated measures ANOVA.
 #' @examples
 #' data(selfesteem)
-#' head(as.data.frame(selfesteem))
+#' head(selfesteem)
+#'
+#' # One-way repeated measures ANOVA of the self-esteem score over time
+#' selfesteem_long <- reshape(selfesteem, varying = c("t1", "t2", "t3"),
+#'                            v.names = "score", timevar = "time",
+#'                            direction = "long")
+#' summary(aov(score ~ factor(time) + Error(factor(id)/factor(time)),
+#'             data = selfesteem_long))
 NULL

--- a/R/selfesteem2.R
+++ b/R/selfesteem2.R
@@ -16,8 +16,27 @@
 #'@name selfesteem2
 #'@docType data
 #'@usage data("selfesteem2")
-#'@format A data frame with 24 rows and 5 columns.
+#'@format A data frame with 24 rows and 5 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 12); each participant takes part in
+#'      both trials.}
+#'    \item{treatment}{the trial, "ctr" (control/placebo) or "Diet".}
+#'    \item{t1}{the self esteem score at the beginning of the trial.}
+#'    \item{t2}{the self esteem score midway through the trial.}
+#'    \item{t3}{the self esteem score at the end of the trial.}
+#'  }
+#'  The self esteem score is a simulated measure on an arbitrary scale with no
+#'  real-world units.
+#'@source A simulated dataset created for teaching two-way repeated measures ANOVA.
 #' @examples
 #' data(selfesteem2)
-#' head(as.data.frame(selfesteem2))
+#' head(selfesteem2)
+#'
+#' # Two-way repeated measures ANOVA (treatment x time), both within-subjects
+#' selfesteem2_long <- reshape(selfesteem2, varying = c("t1", "t2", "t3"),
+#'                             v.names = "score", timevar = "time",
+#'                             idvar = c("id", "treatment"), direction = "long")
+#' summary(aov(score ~ treatment * factor(time) +
+#'               Error(factor(id)/(treatment * factor(time))),
+#'             data = selfesteem2_long))
 NULL

--- a/R/weightloss.R
+++ b/R/weightloss.R
@@ -20,8 +20,29 @@
 #'@name weightloss
 #'@docType data
 #'@usage data("weightloss")
-#'@format A data frame with 48 rows and 6 columns.
+#'@format A data frame with 48 rows and 6 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 12); each participant performs all
+#'      four diet/exercises trials.}
+#'    \item{diet}{whether the trial included a diet, "no" or "yes".}
+#'    \item{exercises}{whether the trial included exercises, "no" or "yes".}
+#'    \item{t1}{the weight loss score at the beginning of the trial.}
+#'    \item{t2}{the weight loss score at the midpoint of the trial.}
+#'    \item{t3}{the weight loss score at the end of the trial.}
+#'  }
+#'  The weight loss score is a simulated measure on an arbitrary scale with no
+#'  real-world units.
+#'@source A simulated dataset created for teaching three-way repeated measures ANOVA.
 #' @examples
 #' data(weightloss)
-#' head(as.data.frame(weightloss))
+#' head(weightloss)
+#'
+#' # Three-way repeated measures ANOVA (diet x exercises x time), all within
+#' weightloss_long <- reshape(weightloss, varying = c("t1", "t2", "t3"),
+#'                            v.names = "score", timevar = "time",
+#'                            idvar = c("id", "diet", "exercises"),
+#'                            direction = "long")
+#' summary(aov(score ~ diet * exercises * factor(time) +
+#'               Error(factor(id)/(diet * exercises * factor(time))),
+#'             data = weightloss_long))
 NULL

--- a/man/depression.Rd
+++ b/man/depression.Rd
@@ -5,7 +5,20 @@
 \alias{depression}
 \title{Depression Data for Two Way Mixed ANOVA}
 \format{
-A data frame with 24 rows and 6 columns.
+A data frame with 24 rows and 6 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 24).}
+   \item{treatment}{the treatment group, "ctr" (control) or "treated".}
+   \item{t0}{the depression score at pre-test.}
+   \item{t1}{the depression score at the first post-test follow-up.}
+   \item{t2}{the depression score at the second post-test follow-up.}
+   \item{t3}{the depression score at the third post-test follow-up.}
+ }
+ The depression score is a simulated measure on an arbitrary scale with no
+ real-world units.
+}
+\source{
+A simulated dataset created for teaching two-way mixed ANOVA.
 }
 \usage{
 data("depression")
@@ -22,5 +35,12 @@ The data correspond to an experiment in which a treatment for depression is
 }
 \examples{
 data(depression)
-head(as.data.frame(depression))
+head(depression)
+
+# Two-way mixed ANOVA: treatment (between) x time (within)
+depression_long <- reshape(depression, varying = c("t0", "t1", "t2", "t3"),
+                           v.names = "score", timevar = "time",
+                           direction = "long")
+summary(aov(score ~ treatment * factor(time) + Error(factor(id)/factor(time)),
+            data = depression_long))
 }

--- a/man/selfesteem.Rd
+++ b/man/selfesteem.Rd
@@ -5,7 +5,18 @@
 \alias{selfesteem}
 \title{Self-Esteem Score Data for One-way Repeated Measures ANOVA}
 \format{
-A data frame with 10 rows and 4 columns.
+A data frame with 10 rows and 4 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 10).}
+   \item{t1}{the self-esteem score at the first time point.}
+   \item{t2}{the self-esteem score at the second time point.}
+   \item{t3}{the self-esteem score at the third time point.}
+ }
+ The self-esteem score is a simulated measure on an arbitrary scale with no
+ real-world units.
+}
+\source{
+A simulated dataset created for teaching one-way repeated measures ANOVA.
 }
 \usage{
 data("selfesteem")
@@ -19,5 +30,12 @@ The dataset contains 10 individuals' self-esteem score on three time points
 }
 \examples{
 data(selfesteem)
-head(as.data.frame(selfesteem))
+head(selfesteem)
+
+# One-way repeated measures ANOVA of the self-esteem score over time
+selfesteem_long <- reshape(selfesteem, varying = c("t1", "t2", "t3"),
+                           v.names = "score", timevar = "time",
+                           direction = "long")
+summary(aov(score ~ factor(time) + Error(factor(id)/factor(time)),
+            data = selfesteem_long))
 }

--- a/man/selfesteem2.Rd
+++ b/man/selfesteem2.Rd
@@ -5,7 +5,20 @@
 \alias{selfesteem2}
 \title{Self Esteem Score Data for Two-way Repeated Measures ANOVA}
 \format{
-A data frame with 24 rows and 5 columns.
+A data frame with 24 rows and 5 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 12); each participant takes part in
+     both trials.}
+   \item{treatment}{the trial, "ctr" (control/placebo) or "Diet".}
+   \item{t1}{the self esteem score at the beginning of the trial.}
+   \item{t2}{the self esteem score midway through the trial.}
+   \item{t3}{the self esteem score at the end of the trial.}
+ }
+ The self esteem score is a simulated measure on an arbitrary scale with no
+ real-world units.
+}
+\source{
+A simulated dataset created for teaching two-way repeated measures ANOVA.
 }
 \usage{
 data("selfesteem2")
@@ -27,5 +40,13 @@ Data are the self esteem score of 12 individuals enrolled in 2
 }
 \examples{
 data(selfesteem2)
-head(as.data.frame(selfesteem2))
+head(selfesteem2)
+
+# Two-way repeated measures ANOVA (treatment x time), both within-subjects
+selfesteem2_long <- reshape(selfesteem2, varying = c("t1", "t2", "t3"),
+                            v.names = "score", timevar = "time",
+                            idvar = c("id", "treatment"), direction = "long")
+summary(aov(score ~ treatment * factor(time) +
+              Error(factor(id)/(treatment * factor(time))),
+            data = selfesteem2_long))
 }

--- a/man/weightloss.Rd
+++ b/man/weightloss.Rd
@@ -5,7 +5,21 @@
 \alias{weightloss}
 \title{Weight Loss Score Data for Three-way Repeated Measures ANOVA}
 \format{
-A data frame with 48 rows and 6 columns.
+A data frame with 48 rows and 6 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 12); each participant performs all
+     four diet/exercises trials.}
+   \item{diet}{whether the trial included a diet, "no" or "yes".}
+   \item{exercises}{whether the trial included exercises, "no" or "yes".}
+   \item{t1}{the weight loss score at the beginning of the trial.}
+   \item{t2}{the weight loss score at the midpoint of the trial.}
+   \item{t3}{the weight loss score at the end of the trial.}
+ }
+ The weight loss score is a simulated measure on an arbitrary scale with no
+ real-world units.
+}
+\source{
+A simulated dataset created for teaching three-way repeated measures ANOVA.
 }
 \usage{
 data("weightloss")
@@ -31,5 +45,14 @@ A researcher wanted to assess the effects of Diet and Exercises
 }
 \examples{
 data(weightloss)
-head(as.data.frame(weightloss))
+head(weightloss)
+
+# Three-way repeated measures ANOVA (diet x exercises x time), all within
+weightloss_long <- reshape(weightloss, varying = c("t1", "t2", "t3"),
+                           v.names = "score", timevar = "time",
+                           idvar = c("id", "diet", "exercises"),
+                           direction = "long")
+summary(aov(score ~ diet * exercises * factor(time) +
+              Error(factor(id)/(diet * exercises * factor(time))),
+            data = weightloss_long))
 }


### PR DESCRIPTION
Adds the full doc bundle to `selfesteem`, `selfesteem2`, `weightloss`, `depression`: `@format \describe{}` per variable, an `@source` marking each as a simulated teaching dataset, and a canonical base-R repeated-measures ANOVA example. Documentation only — data unchanged (byte-identical).

- `selfesteem`: one-way RM ANOVA (time).
- `selfesteem2`: two-way RM ANOVA (treatment x time, both within).
- `weightloss`: three-way RM ANOVA (diet x exercises x time, all within).
- `depression`: two-way mixed ANOVA (treatment between, time within).

Each example reshapes wide->long via `reshape()` and fits `aov(... + Error(...))` — all four verified to run. Score columns documented as a simulated measure on an arbitrary scale (no real-world units), per the agreed framing. Verified: checkRd clean, examples run, dataset-consistency check passes, `data/` untouched.