### PR TITLE
Document the anxiety and stress datasets (variables, source, examples)

### DIFF
--- a/R/anxiety.R
+++ b/R/anxiety.R
@@ -9,8 +9,26 @@
 #'@name anxiety
 #'@docType data
 #'@usage data("anxiety")
-#'@format A data frame with 45 rows and 5 columns.
+#'@format A data frame with 45 rows and 5 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 45).}
+#'    \item{group}{the physical exercise level, "grp1" (basal), "grp2"
+#'      (moderate) or "grp3" (high); a between-subjects factor.}
+#'    \item{t1}{the anxiety score at the first time point.}
+#'    \item{t2}{the anxiety score at the second time point.}
+#'    \item{t3}{the anxiety score at the third time point.}
+#'  }
+#'  The anxiety score is a simulated measure on an arbitrary scale with no
+#'  real-world units.
+#'@source A simulated dataset created for teaching two-way mixed ANOVA.
 #' @examples
 #' data(anxiety)
-#' head(as.data.frame(anxiety))
+#' head(anxiety)
+#'
+#' # Two-way mixed ANOVA: group (between) x time (within)
+#' anxiety_long <- reshape(anxiety, varying = c("t1", "t2", "t3"),
+#'                         v.names = "score", timevar = "time",
+#'                         direction = "long")
+#' summary(aov(score ~ group * factor(time) + Error(factor(id)/factor(time)),
+#'             data = anxiety_long))
 NULL

--- a/R/stress.R
+++ b/R/stress.R
@@ -9,8 +9,21 @@
 #'@name stress
 #'@docType data
 #'@usage data("stress")
-#'@format A data frame with 60 rows and 5 columns.
+#'@format A data frame with 60 rows and 5 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 60).}
+#'    \item{score}{the stress score; a simulated measure on an arbitrary scale
+#'      with no real-world units.}
+#'    \item{treatment}{whether the participant received the treatment, "yes" or
+#'      "no".}
+#'    \item{exercise}{the exercise level, "low", "moderate" or "high".}
+#'    \item{age}{the participant's age, in years.}
+#'  }
+#'@source A simulated dataset created for teaching two-way ANCOVA.
 #' @examples
 #' data(stress)
-#' head(as.data.frame(stress))
+#' head(stress)
+#'
+#' # Two-way ANCOVA of the stress score, adjusting for age
+#' summary(aov(score ~ age + treatment * exercise, data = stress))
 NULL

--- a/man/anxiety.Rd
+++ b/man/anxiety.Rd
@@ -5,7 +5,20 @@
 \alias{anxiety}
 \title{Anxiety Data for Two-Way Mixed ANOVA}
 \format{
-A data frame with 45 rows and 5 columns.
+A data frame with 45 rows and 5 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 45).}
+   \item{group}{the physical exercise level, "grp1" (basal), "grp2"
+     (moderate) or "grp3" (high); a between-subjects factor.}
+   \item{t1}{the anxiety score at the first time point.}
+   \item{t2}{the anxiety score at the second time point.}
+   \item{t3}{the anxiety score at the third time point.}
+ }
+ The anxiety score is a simulated measure on an arbitrary scale with no
+ real-world units.
+}
+\source{
+A simulated dataset created for teaching two-way mixed ANOVA.
 }
 \usage{
 data("anxiety")
@@ -20,5 +33,12 @@ The data provide the anxiety score, measured at three time
 }
 \examples{
 data(anxiety)
-head(as.data.frame(anxiety))
+head(anxiety)
+
+# Two-way mixed ANOVA: group (between) x time (within)
+anxiety_long <- reshape(anxiety, varying = c("t1", "t2", "t3"),
+                        v.names = "score", timevar = "time",
+                        direction = "long")
+summary(aov(score ~ group * factor(time) + Error(factor(id)/factor(time)),
+            data = anxiety_long))
 }

--- a/man/stress.Rd
+++ b/man/stress.Rd
@@ -5,7 +5,19 @@
 \alias{stress}
 \title{Stress Data for Two-Way ANCOVA}
 \format{
-A data frame with 60 rows and 5 columns.
+A data frame with 60 rows and 5 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 60).}
+   \item{score}{the stress score; a simulated measure on an arbitrary scale
+     with no real-world units.}
+   \item{treatment}{whether the participant received the treatment, "yes" or
+     "no".}
+   \item{exercise}{the exercise level, "low", "moderate" or "high".}
+   \item{age}{the participant's age, in years.}
+ }
+}
+\source{
+A simulated dataset created for teaching two-way ANCOVA.
 }
 \usage{
 data("stress")
@@ -20,5 +32,8 @@ Researchers want to evaluate the effect of a new "treatment" and
 }
 \examples{
 data(stress)
-head(as.data.frame(stress))
+head(stress)
+
+# Two-way ANCOVA of the stress score, adjusting for age
+summary(aov(score ~ age + treatment * exercise, data = stress))
 }


### PR DESCRIPTION
Adds the full doc bundle to `anxiety` and `stress`: `@format \describe{}`, `@source` (simulated teaching dataset), and a canonical base-R example. Documentation only — data unchanged (byte-identical).

- `anxiety`: two-way mixed ANOVA (group between, time within); reshaped to long with the within factor wrapped as `factor(time)` in `Error()`.
- `stress`: two-way ANCOVA of the stress score adjusting for age (`aov(score ~ age + treatment * exercise)`).

`stress`'s `\describe` documents `score` as the stress score and `age` as age (in years), directly clarifying the column meanings raised in issue #2. Score columns documented as a simulated measure on an arbitrary scale with no real-world units. Verified: checkRd clean, examples run, dataset-consistency check passes, `data/` untouched.