### PR TITLE
Document the real-data datasets (variables, source, references, examples)

### DIFF
--- a/R/AirPassengersDf.R
+++ b/R/AirPassengersDf.R
@@ -6,8 +6,20 @@
 #'@name AirPassengersDf
 #'@docType data
 #'@usage data("AirPassengersDf")
-#'@format A data frame with 144 rows and 2 columns (Month and Passengers).
+#'@format A data frame with 144 rows and 2 columns.
+#'  \describe{
+#'    \item{Month}{the month of the observation, as a \code{Date} (the first day
+#'      of each month from January 1949 to December 1960).}
+#'    \item{Passengers}{the monthly total of international airline passengers.}
+#'  }
+#'@source The \code{AirPassengers} time series in base R (the classic Box and
+#'  Jenkins airline data), reshaped into a long data frame.
+#'@references Box, G. E. P., Jenkins, G. M. and Reinsel, G. C. (1976) Time
+#'  Series Analysis, Forecasting and Control. San Francisco: Holden-Day.
 #' @examples
 #' data("AirPassengersDf")
 #' head(AirPassengersDf)
+#'
+#' # Monthly international airline passengers over time
+#' plot(Passengers ~ Month, data = AirPassengersDf, type = "l")
 NULL

--- a/R/housetasks.raw.R
+++ b/R/housetasks.raw.R
@@ -4,9 +4,27 @@
 #'@name housetasks.raw
 #'@docType data
 #'@usage data("housetasks.raw")
-#'@format A data frame with 1744 rows and 2 columns (tasks and status).
+#'@format A data frame with 1744 rows and 2 columns (stored as a tibble). Each
+#'  row is one recorded performance of a household task, recovered from the
+#'  original contingency table.
+#'  \describe{
+#'    \item{tasks}{the household task, one of 13 categories: "Laundry",
+#'      "Main_meal", "Dinner", "Breakfeast", "Tidying", "Dishes", "Shopping",
+#'      "Official", "Driving", "Finances", "Insurance", "Repairs" and
+#'      "Holidays". ("Breakfeast" is a misspelling of "Breakfast" carried over
+#'      from the source data.)}
+#'    \item{status}{who performs the task: "Partner1", "Alternating", "Parter2"
+#'      or "Jointly". The two partner categories were relabeled from the source
+#'      data's "Wife" and "Husband"; "Parter2" is a misspelling of "Partner2"
+#'      retained as-is in the stored data.}
+#'  }
+#'@source Derived from the \code{housetasks} data set in the \pkg{factoextra}
+#'  package, with its "Wife" and "Husband" columns relabeled "Partner1" and
+#'  "Partner2", expanded to one row per recorded case.
 #' @examples
 #' data(housetasks.raw)
 #' table(housetasks.raw)
 #'
+#' # Chi-square test of association between task and who performs it
+#' chisq.test(table(housetasks.raw$tasks, housetasks.raw$status))
 NULL

--- a/R/renalstone.R
+++ b/R/renalstone.R
@@ -7,10 +7,17 @@
 #'@name renalstone
 #'@docType data
 #'@usage data("renalstone")
-#'@format A data frame with 3513 rows and 3 columns.
-#'@references Hazra, Avijit, and Nithya Jaideep Gogtay. 2016. “Biostatistics
-#'Series Module 4: Comparing Groups – Categorical Variables.” In Indian Journal
-#'of Dermatology
+#'@format A data frame with 3513 rows and 3 columns (stored as a tibble).
+#'  \describe{
+#'    \item{gender}{the individual's gender, "male" or "female".}
+#'    \item{stone}{whether the individual has a renal stone, "yes" or "no".}
+#'    \item{age}{the age group, an ordered factor: "30-39" < "40-49" < "50-59".}
+#'  }
+#'@source Frequencies reported by Hazra and Gogtay (2016), expanded to one row
+#'  per individual.
+#'@references Hazra, Avijit, and Nithya Jaideep Gogtay. 2016. "Biostatistics
+#'Series Module 4: Comparing Groups - Categorical Variables." In Indian Journal
+#'of Dermatology.
 #' @examples
 #' data(renalstone)
 #' xtabs(~stone+age+gender, data = renalstone)

--- a/R/titanic.raw.R
+++ b/R/titanic.raw.R
@@ -2,15 +2,22 @@
 #'
 #'@description Survival of passengers on the Titanic. This data set provides
 #'  information on the fate of passengers on the fatal maiden voyage of the
-#'  ocean liner ‘Titanic’. Columns are economic status (Class), Sex,
+#'  ocean liner "Titanic". Columns are economic status (Class), Sex,
 #'  Age and Survived.
 #'@name titanic.raw
 #'@docType data
 #'@usage data("titanic.raw")
 #'@format A data frame with 2201 rows and 4 columns.
+#'  \describe{
+#'    \item{Class}{the passenger's economic status, "1st", "2nd", "3rd" or
+#'      "Crew".}
+#'    \item{Sex}{the passenger's sex, "Male" or "Female".}
+#'    \item{Age}{the age category, "Child" or "Adult".}
+#'    \item{Survived}{whether the passenger survived, "No" or "Yes".}
+#'  }
+#'@source Derived from the \code{Titanic} data set in base R, expanded to one
+#'  row per passenger.
 #' @examples
 #' data(titanic.raw)
-#' data("titanic.raw")
 #' with(titanic.raw, table(Class, Survived))
-#'
 NULL

--- a/man/AirPassengersDf.Rd
+++ b/man/AirPassengersDf.Rd
@@ -5,7 +5,16 @@
 \alias{AirPassengersDf}
 \title{Air Passengers}
 \format{
-A data frame with 144 rows and 2 columns (Month and Passengers).
+A data frame with 144 rows and 2 columns.
+ \describe{
+   \item{Month}{the month of the observation, as a \code{Date} (the first day
+     of each month from January 1949 to December 1960).}
+   \item{Passengers}{the monthly total of international airline passengers.}
+ }
+}
+\source{
+The \code{AirPassengers} time series in base R (the classic Box and
+ Jenkins airline data), reshaped into a long data frame.
 }
 \usage{
 data("AirPassengersDf")
@@ -18,4 +27,11 @@ data frame format.
 \examples{
 data("AirPassengersDf")
 head(AirPassengersDf)
+
+# Monthly international airline passengers over time
+plot(Passengers ~ Month, data = AirPassengersDf, type = "l")
+}
+\references{
+Box, G. E. P., Jenkins, G. M. and Reinsel, G. C. (1976) Time
+ Series Analysis, Forecasting and Control. San Francisco: Holden-Day.
 }

--- a/man/housetasks.raw.Rd
+++ b/man/housetasks.raw.Rd
@@ -5,7 +5,25 @@
 \alias{housetasks.raw}
 \title{Housetasks}
 \format{
-A data frame with 1744 rows and 2 columns (tasks and status).
+A data frame with 1744 rows and 2 columns (stored as a tibble). Each
+ row is one recorded performance of a household task, recovered from the
+ original contingency table.
+ \describe{
+   \item{tasks}{the household task, one of 13 categories: "Laundry",
+     "Main_meal", "Dinner", "Breakfeast", "Tidying", "Dishes", "Shopping",
+     "Official", "Driving", "Finances", "Insurance", "Repairs" and
+     "Holidays". ("Breakfeast" is a misspelling of "Breakfast" carried over
+     from the source data.)}
+   \item{status}{who performs the task: "Partner1", "Alternating", "Parter2"
+     or "Jointly". The two partner categories were relabeled from the source
+     data's "Wife" and "Husband"; "Parter2" is a misspelling of "Partner2"
+     retained as-is in the stored data.}
+ }
+}
+\source{
+Derived from the \code{housetasks} data set in the \pkg{factoextra}
+ package, with its "Wife" and "Husband" columns relabeled "Partner1" and
+ "Partner2", expanded to one row per recorded case.
 }
 \usage{
 data("housetasks.raw")
@@ -17,4 +35,6 @@ A data frame containing the frequency of execution of 13 house tasks in the coup
 data(housetasks.raw)
 table(housetasks.raw)
 
+# Chi-square test of association between task and who performs it
+chisq.test(table(housetasks.raw$tasks, housetasks.raw$status))
 }

--- a/man/renalstone.Rd
+++ b/man/renalstone.Rd
@@ -5,7 +5,16 @@
 \alias{renalstone}
 \title{Risk of Renal Stone Data for Cochran-Armitage Trend Test}
 \format{
-A data frame with 3513 rows and 3 columns.
+A data frame with 3513 rows and 3 columns (stored as a tibble).
+ \describe{
+   \item{gender}{the individual's gender, "male" or "female".}
+   \item{stone}{whether the individual has a renal stone, "yes" or "no".}
+   \item{age}{the age group, an ordered factor: "30-39" < "40-49" < "50-59".}
+ }
+}
+\source{
+Frequencies reported by Hazra and Gogtay (2016), expanded to one row
+ per individual.
 }
 \usage{
 data("renalstone")
@@ -21,7 +30,7 @@ data(renalstone)
 xtabs(~stone+age+gender, data = renalstone)
 }
 \references{
-Hazra, Avijit, and Nithya Jaideep Gogtay. 2016. “Biostatistics
-Series Module 4: Comparing Groups – Categorical Variables.” In Indian Journal
-of Dermatology
+Hazra, Avijit, and Nithya Jaideep Gogtay. 2016. "Biostatistics
+Series Module 4: Comparing Groups - Categorical Variables." In Indian Journal
+of Dermatology.
 }

--- a/man/titanic.raw.Rd
+++ b/man/titanic.raw.Rd
@@ -6,6 +6,17 @@
 \title{Survival of Passengers on the Titanic}
 \format{
 A data frame with 2201 rows and 4 columns.
+ \describe{
+   \item{Class}{the passenger's economic status, "1st", "2nd", "3rd" or
+     "Crew".}
+   \item{Sex}{the passenger's sex, "Male" or "Female".}
+   \item{Age}{the age category, "Child" or "Adult".}
+   \item{Survived}{whether the passenger survived, "No" or "Yes".}
+ }
+}
+\source{
+Derived from the \code{Titanic} data set in base R, expanded to one
+ row per passenger.
 }
 \usage{
 data("titanic.raw")
@@ -13,12 +24,10 @@ data("titanic.raw")
 \description{
 Survival of passengers on the Titanic. This data set provides
  information on the fate of passengers on the fatal maiden voyage of the
- ocean liner ‘Titanic’. Columns are economic status (Class), Sex,
+ ocean liner "Titanic". Columns are economic status (Class), Sex,
  Age and Survived.
 }
 \examples{
 data(titanic.raw)
-data("titanic.raw")
 with(titanic.raw, table(Class, Survived))
-
 }


### PR DESCRIPTION
Adds `@format \describe{}` and, for these real-derived datasets, an `@source` citing the actual origin (plus `@references`). Documentation only — data unchanged (byte-identical).

- `AirPassengersDf`: from base R `AirPassengers` (Box and Jenkins airline data); adds a time-series plot example + the Box/Jenkins/Reinsel reference.
- `housetasks.raw`: recovered from factoextra's `housetasks` contingency table; the **frozen source spellings** "Breakfeast" and "Parter2" are documented as-is (flagged "spelt as in the source data"), not corrected. Adds a chi-square example.
- `titanic.raw`: recovered from base R `Titanic`; documents Class/Sex/Age/Survived.
- `renalstone`: adds per-variable `\describe` (ordered age groups) + an `@source`; keeps the Hazra and Gogtay (2016) reference.

Also converts curly quotes/dashes in titanic.raw and renalstone to ASCII. Verified: checkRd clean (no non-ASCII), examples run (no warnings), dataset-consistency check passes, `data/` untouched.