### PR TITLE
Document the regression, proportions and paired-nominal datasets

### DIFF
--- a/R/antismoking.R
+++ b/R/antismoking.R
@@ -6,8 +6,19 @@
 #'@name antismoking
 #'@docType data
 #'@usage data("antismoking")
-#'@format A data frame with 62 rows and 3 columns.
+#'@format A data frame with 62 rows and 3 columns (stored as a tibble).
+#'  \describe{
+#'    \item{id}{participant identifier (1 to 62).}
+#'    \item{before}{the smoking status before the communication, "non.smoker"
+#'      or "smoker".}
+#'    \item{after}{the smoking status after the communication, "non.smoker" or
+#'      "smoker".}
+#'  }
+#'@source A simulated dataset for teaching McNemar's test.
 #' @examples
 #' data(antismoking)
 #' xtabs(~before + after, data = antismoking)
+#'
+#' # McNemar test of the change in smoking status
+#' mcnemar.test(table(antismoking$before, antismoking$after))
 NULL

--- a/R/marketing.R
+++ b/R/marketing.R
@@ -8,6 +8,16 @@
 #'@docType data
 #'@usage data("marketing")
 #'@format A data frame with 200 rows and 4 columns.
+#'  \describe{
+#'    \item{youtube}{the advertising budget spent on YouTube, in thousands of
+#'      dollars.}
+#'    \item{facebook}{the advertising budget spent on Facebook, in thousands of
+#'      dollars.}
+#'    \item{newspaper}{the advertising budget spent on newspaper, in thousands
+#'      of dollars.}
+#'    \item{sales}{the sales generated, in thousands of units.}
+#'  }
+#'@source A simulated dataset for teaching multiple linear regression.
 #' @examples
 #' data(marketing)
 #' res.lm <- lm(sales ~ youtube*facebook, data = marketing)

--- a/R/properties.R
+++ b/R/properties.R
@@ -14,8 +14,18 @@
 #'@name properties
 #'@docType data
 #'@usage data("properties")
-#'@format A data frame with 333 rows and 2 columns.
+#'@format A data frame with 333 rows and 2 columns (stored as a tibble).
+#'  \describe{
+#'    \item{property_type}{the type of property purchased: "flat", "bungalow",
+#'      "detached house" or "terrace".}
+#'    \item{buyer_type}{the type of buyer: "single male", "single female",
+#'      "married couple" or "family".}
+#'  }
+#'@source A simulated dataset for teaching the chi-square test of independence.
 #' @examples
 #' data("properties")
-#' head(as.data.frame(properties))
+#' head(properties)
+#'
+#' # Chi-square test of independence between buyer type and property type
+#' chisq.test(table(properties$property_type, properties$buyer_type))
 NULL

--- a/R/taskachievment.R
+++ b/R/taskachievment.R
@@ -7,8 +7,18 @@
 #'@name taskachievment
 #'@docType data
 #'@usage data("taskachievment")
-#'@format A data frame with 73 rows and 4 columns.
+#'@format A data frame with 73 rows and 4 columns (stored as a tibble).
+#'  \describe{
+#'    \item{participant}{participant identifier (1 to 73).}
+#'    \item{Task1}{the outcome of task 1: 0 (failure) or 1 (success).}
+#'    \item{Task2}{the outcome of task 2: 0 (failure) or 1 (success).}
+#'    \item{Task3}{the outcome of task 3: 0 (failure) or 1 (success).}
+#'  }
+#'@source A simulated dataset for teaching Cochran's Q test.
 #' @examples
 #' data(taskachievment)
 #' head(taskachievment)
+#'
+#' # Proportion of success for each task
+#' colMeans(taskachievment[, c("Task1", "Task2", "Task3")])
 NULL

--- a/man/antismoking.Rd
+++ b/man/antismoking.Rd
@@ -5,7 +5,17 @@
 \alias{antismoking}
 \title{Anti-Smoking Emotive Communication Data for McNemar Test}
 \format{
-A data frame with 62 rows and 3 columns.
+A data frame with 62 rows and 3 columns (stored as a tibble).
+ \describe{
+   \item{id}{participant identifier (1 to 62).}
+   \item{before}{the smoking status before the communication, "non.smoker"
+     or "smoker".}
+   \item{after}{the smoking status after the communication, "non.smoker" or
+     "smoker".}
+ }
+}
+\source{
+A simulated dataset for teaching McNemar's test.
 }
 \usage{
 data("antismoking")
@@ -18,4 +28,7 @@ This a demo dataset for McNemar test.
 \examples{
 data(antismoking)
 xtabs(~before + after, data = antismoking)
+
+# McNemar test of the change in smoking status
+mcnemar.test(table(antismoking$before, antismoking$after))
 }

--- a/man/marketing.Rd
+++ b/man/marketing.Rd
@@ -6,6 +6,18 @@
 \title{Marketing Data Set}
 \format{
 A data frame with 200 rows and 4 columns.
+ \describe{
+   \item{youtube}{the advertising budget spent on YouTube, in thousands of
+     dollars.}
+   \item{facebook}{the advertising budget spent on Facebook, in thousands of
+     dollars.}
+   \item{newspaper}{the advertising budget spent on newspaper, in thousands
+     of dollars.}
+   \item{sales}{the sales generated, in thousands of units.}
+ }
+}
+\source{
+A simulated dataset for teaching multiple linear regression.
 }
 \usage{
 data("marketing")

--- a/man/properties.Rd
+++ b/man/properties.Rd
@@ -5,7 +5,16 @@
 \alias{properties}
 \title{Properties Data for Chi-square Test of Independence}
 \format{
-A data frame with 333 rows and 2 columns.
+A data frame with 333 rows and 2 columns (stored as a tibble).
+ \describe{
+   \item{property_type}{the type of property purchased: "flat", "bungalow",
+     "detached house" or "terrace".}
+   \item{buyer_type}{the type of buyer: "single male", "single female",
+     "married couple" or "family".}
+ }
+}
+\source{
+A simulated dataset for teaching the chi-square test of independence.
 }
 \usage{
 data("properties")
@@ -25,5 +34,8 @@ Contains the type of properties and the buyer types. Buyer
 }
 \examples{
 data("properties")
-head(as.data.frame(properties))
+head(properties)
+
+# Chi-square test of independence between buyer type and property type
+chisq.test(table(properties$property_type, properties$buyer_type))
 }

--- a/man/taskachievment.Rd
+++ b/man/taskachievment.Rd
@@ -5,7 +5,16 @@
 \alias{taskachievment}
 \title{Task Achievment Data for Cochran's Q Test}
 \format{
-A data frame with 73 rows and 4 columns.
+A data frame with 73 rows and 4 columns (stored as a tibble).
+ \describe{
+   \item{participant}{participant identifier (1 to 73).}
+   \item{Task1}{the outcome of task 1: 0 (failure) or 1 (success).}
+   \item{Task2}{the outcome of task 2: 0 (failure) or 1 (success).}
+   \item{Task3}{the outcome of task 3: 0 (failure) or 1 (success).}
+ }
+}
+\source{
+A simulated dataset for teaching Cochran's Q test.
 }
 \usage{
 data("taskachievment")
@@ -19,4 +28,7 @@ Repeated measures nominal designs where 73 subjects are asked to
 \examples{
 data(taskachievment)
 head(taskachievment)
+
+# Proportion of success for each task
+colMeans(taskachievment[, c("Task1", "Task2", "Task3")])
 }


### PR DESCRIPTION
Completes the per-variable documentation sweep with `marketing`, `properties`, `antismoking`, `taskachievment` (`@format \describe{}` + `@source` + canonical base-R example each). **All 21 datasets now carry `\describe{}`.** Documentation only - data unchanged (byte-identical).

- `marketing`: documents the four columns and their units (ad budgets in thousands of dollars, sales in thousands of units) - clarifying the units question in issue #1; `lm(sales ~ youtube*facebook)` example.
- `properties`: chi-square test of independence example.
- `antismoking`: McNemar test (paired before/after smoking status).
- `taskachievment`: per-task success proportions (Cochran's Q design; base R has no Q test, so the example shows the success rates).

Simulated teaching datasets marked in `@source`; units stated only where the existing text establishes them. Verified: checkRd clean, examples run (no warnings), dataset-consistency check passes all 21, `data/` untouched.