### PR TITLE
Add @source to the first-documented datasets; tidy the performance example

### DIFF
--- a/R/genderweight.R
+++ b/R/genderweight.R
@@ -14,6 +14,7 @@
 #'    \item{group}{the participant's sex, "F" (female) or "M" (male).}
 #'    \item{weight}{the participant's body weight.}
 #'  }
+#'@source A simulated dataset for teaching the two-samples (independent) t-test.
 #' @examples
 #' data(genderweight)
 #' head(genderweight)

--- a/R/headache.R
+++ b/R/headache.R
@@ -22,6 +22,7 @@
 #'    \item{pain_score}{a simulated migraine pain score (an arbitrary scale with
 #'      no real-world units).}
 #'  }
+#'@source A simulated dataset for teaching three-way ANOVA.
 #' @examples
 #' data(headache)
 #' head(headache)

--- a/R/heartattack.R
+++ b/R/heartattack.R
@@ -21,6 +21,7 @@
 #'    \item{cholesterol}{the blood cholesterol concentration.}
 #'    \item{id}{participant identifier (1 to 72).}
 #'  }
+#'@source A simulated dataset for teaching three-way ANOVA.
 #' @examples
 #' data(heartattack)
 #' head(heartattack)

--- a/R/jobsatisfaction.R
+++ b/R/jobsatisfaction.R
@@ -14,6 +14,7 @@
 #'    \item{score}{a simulated job satisfaction score (an arbitrary scale with
 #'      no real-world units).}
 #'  }
+#'@source A simulated dataset for teaching two-way ANOVA.
 #' @examples
 #' data(jobsatisfaction)
 #' head(jobsatisfaction)

--- a/R/mice.R
+++ b/R/mice.R
@@ -12,6 +12,7 @@
 #'    \item{name}{mouse identifier, "M_1" to "M_10".}
 #'    \item{weight}{the mouse weight, in grams.}
 #'  }
+#'@source A simulated dataset for teaching the one-sample t-test.
 #' @examples
 #' data(mice)
 #' head(mice)

--- a/R/mice2.R
+++ b/R/mice2.R
@@ -12,6 +12,7 @@
 #'    \item{before}{the mouse weight before the treatment.}
 #'    \item{after}{the mouse weight after the treatment.}
 #'  }
+#'@source A simulated dataset for teaching the paired-samples t-test.
 #' @examples
 #' data(mice2)
 #' head(mice2)

--- a/R/performance.R
+++ b/R/performance.R
@@ -19,6 +19,7 @@
 #'      arbitrary scale with no real-world units).}
 #'    \item{t2}{the performance score at the second time point (same scale as t1).}
 #'  }
+#'@source A simulated dataset for teaching three-way mixed ANOVA.
 #' @examples
 #' data(performance)
 #' head(performance)
@@ -26,6 +27,6 @@
 #' # Three-way mixed ANOVA: gender and stress (between) x time (within)
 #' perf_long <- reshape(performance, varying = c("t1", "t2"),
 #'                      v.names = "score", timevar = "time", direction = "long")
-#' summary(aov(score ~ gender * stress * factor(time) + Error(factor(id)/time),
+#' summary(aov(score ~ gender * stress * factor(time) + Error(factor(id)/factor(time)),
 #'             data = perf_long))
 NULL

--- a/man/genderweight.Rd
+++ b/man/genderweight.Rd
@@ -12,6 +12,9 @@ A data frame with 40 rows and 3 columns (stored as a tibble).
    \item{weight}{the participant's body weight.}
  }
 }
+\source{
+A simulated dataset for teaching the two-samples (independent) t-test.
+}
 \usage{
 data("genderweight")
 }

--- a/man/headache.Rd
+++ b/man/headache.Rd
@@ -15,6 +15,9 @@ A data frame with 72 rows and 5 columns (stored as a tibble).
      no real-world units).}
  }
 }
+\source{
+A simulated dataset for teaching three-way ANOVA.
+}
 \usage{
 data("headache")
 }

--- a/man/heartattack.Rd
+++ b/man/heartattack.Rd
@@ -14,6 +14,9 @@ A data frame with 72 rows and 5 columns (stored as a tibble).
    \item{id}{participant identifier (1 to 72).}
  }
 }
+\source{
+A simulated dataset for teaching three-way ANOVA.
+}
 \usage{
 data("heartattack")
 }

--- a/man/jobsatisfaction.Rd
+++ b/man/jobsatisfaction.Rd
@@ -15,6 +15,9 @@ A data frame with 58 rows and 4 columns (stored as a tibble).
      no real-world units).}
  }
 }
+\source{
+A simulated dataset for teaching two-way ANOVA.
+}
 \usage{
 data("jobsatisfaction")
 }

--- a/man/mice.Rd
+++ b/man/mice.Rd
@@ -11,6 +11,9 @@ A data frame with 10 rows and 2 columns (stored as a tibble).
    \item{weight}{the mouse weight, in grams.}
  }
 }
+\source{
+A simulated dataset for teaching the one-sample t-test.
+}
 \usage{
 data("mice")
 }

--- a/man/mice2.Rd
+++ b/man/mice2.Rd
@@ -12,6 +12,9 @@ A data frame with 10 rows and 3 columns.
    \item{after}{the mouse weight after the treatment.}
  }
 }
+\source{
+A simulated dataset for teaching the paired-samples t-test.
+}
 \usage{
 data("mice2")
 }

--- a/man/performance.Rd
+++ b/man/performance.Rd
@@ -15,6 +15,9 @@ A data frame with 60 rows and 5 columns (stored as a tibble).
    \item{t2}{the performance score at the second time point (same scale as t1).}
  }
 }
+\source{
+A simulated dataset for teaching three-way mixed ANOVA.
+}
 \usage{
 data("performance")
 }
@@ -34,6 +37,6 @@ head(performance)
 # Three-way mixed ANOVA: gender and stress (between) x time (within)
 perf_long <- reshape(performance, varying = c("t1", "t2"),
                      v.names = "score", timevar = "time", direction = "long")
-summary(aov(score ~ gender * stress * factor(time) + Error(factor(id)/time),
+summary(aov(score ~ gender * stress * factor(time) + Error(factor(id)/factor(time)),
             data = perf_long))
 }


### PR DESCRIPTION
Backfills an `@source` ("A simulated dataset for teaching <analysis>") on the seven datasets documented earlier in the sweep, so **all 21 datasets now carry `@source`** (consistent with the simulated/arbitrary-scale framing agreed earlier).

Also changes `performance`'s example from `Error(factor(id)/time)` to `Error(factor(id)/factor(time))` for consistency with the other repeated-measures examples; with two time points the result is numerically identical (label-only tidy).

Documentation only - data unchanged (byte-identical). Verified: checkRd clean, examples run, dataset-consistency check passes all 21, `data/` untouched.