### PR TITLE
Add verify-not-overwrite provenance scripts to data-raw

### DIFF
--- a/data-raw/AirPassengersDf.R
+++ b/data-raw/AirPassengersDf.R
@@ -1,15 +1,17 @@
-## code to prepare `DATASET` dataset goes here
+## Provenance / regeneration check for AirPassengersDf. Base R only.
+##
+## Derivation: the base R `AirPassengers` monthly time series (1949-1960),
+## reshaped to a long data frame with the first day of each month as `Month`.
+## The shipped data/AirPassengersDf.rda is byte-frozen; this reconstructs the
+## object and VERIFIES it fingerprint-identical to the shipped one -- it never
+## overwrites the .rda (the earlier version called usethis::use_data(overwrite =
+## TRUE), which would change the frozen bytes).
 
-library(zoo)
-library(readr)
-df <- data.frame(
-  Month = as.Date(zoo::as.yearmon(time(AirPassengers))), 
+source("data-raw/verify.R")   # verify_against_shipped()
+
+rebuild <- data.frame(
+  Month      = seq(as.Date("1949-01-01"), by = "month", length.out = length(AirPassengers)),
   Passengers = as.numeric(AirPassengers)
-  )
+)
 
-AirPassengersDf <- df
-
-readr::write_csv(AirPassengersDf, "data-raw/AirPassengersDf.csv")
-
-
-usethis::use_data(AirPassengersDf, overwrite = TRUE)
+verify_against_shipped("AirPassengersDf", rebuild, exact = TRUE)

--- a/data-raw/README.md
+++ b/data-raw/README.md
@@ -1,0 +1,42 @@
+# data-raw
+
+Provenance and regeneration scripts for the datarium datasets. This directory is
+`.Rbuildignore`d — it is kept in git but does **not** ship to CRAN, so its
+scripts may use packages (factoextra, tibble, …) that are **not** datarium
+dependencies.
+
+The shipped `data/*.rda` files are **byte-frozen** (lessons and committed Quarto
+freezes depend on the exact bytes). These scripts therefore **verify** a
+reconstruction against the shipped object and **never overwrite** it — none of
+them calls `usethis::use_data()`. Run a script from the package root, e.g.:
+
+```r
+source("data-raw/titanic.raw.R")
+```
+
+`verify.R` provides `verify_against_shipped(name, rebuild, exact)`:
+`exact = TRUE` requires the reconstruction to be `identical()` to the shipped
+object (values, order and structure; `identical()` ignores the order of
+attributes, so it is the right "same data" test); `exact = FALSE` requires only
+structural identity (class, dims, names, types, factor levels).
+
+## Deterministic-derived (exactly reproducible)
+All three are verified `identical()` to the shipped object.
+
+- `AirPassengersDf.R` — base R `AirPassengers`, reshaped to long (base R only).
+- `titanic.raw.R` — base R `Titanic`, expanded to one row per passenger (base R
+  only).
+- `housetasks.raw.R` — factoextra `housetasks` (the "Wife"/"Husband" columns
+  relabeled "Partner1"/"Partner2"; the stored data keeps the misspelling
+  "Parter2"), expanded to one row per case.
+
+## Contingency-derived (in `inst/data.R`)
+`antismoking`, `taskachievment` and `renalstone` are constructed from small
+contingency tables in `inst/data.R` (`taskachievment` uses `set.seed(123)`).
+
+## Stochastic-simulated (the remaining datasets)
+The remaining teaching datasets are simulated. Their `@source` documents each as
+"a simulated dataset for teaching <analysis>". Exact regeneration is not
+attempted: they predate a committed seed, and R 3.6's change to `sample()` makes
+exact reproduction impossible even with one — the committed `.rda` is the source
+of truth.

--- a/data-raw/housetasks.raw.R
+++ b/data-raw/housetasks.raw.R
@@ -1,0 +1,24 @@
+## Provenance for housetasks.raw. Needs the factoextra and tibble packages at
+## AUTHORING time only (neither is a datarium dependency).
+##
+## Derivation: factoextra's `housetasks` contingency table, with the "Wife" and
+## "Husband" columns relabeled "Partner1" and "Partner2" (the stored data keeps
+## the frozen misspelling "Parter2"), expanded to one row per recorded case.
+## Verified identical() to the shipped object. It never overwrites the .rda.
+
+if (!requireNamespace("factoextra", quietly = TRUE))
+  stop("factoextra is needed to regenerate housetasks.raw (authoring-time only)")
+if (!requireNamespace("tibble", quietly = TRUE))
+  stop("tibble is needed to regenerate housetasks.raw (authoring-time only)")
+
+source("data-raw/verify.R")   # counts_to_cases(), verify_against_shipped()
+
+utils::data("housetasks", package = "factoextra")
+tab <- as.matrix(housetasks)
+colnames(tab) <- c("Partner1", "Alternating", "Parter2", "Jointly")  # Wife/Husband relabeled
+
+rebuild <- counts_to_cases(as.table(tab))
+names(rebuild) <- c("tasks", "status")
+rebuild <- tibble::as_tibble(rebuild)
+
+verify_against_shipped("housetasks.raw", rebuild, exact = TRUE)

--- a/data-raw/titanic.raw.R
+++ b/data-raw/titanic.raw.R
@@ -1,0 +1,12 @@
+## Provenance / regeneration check for titanic.raw. Base R only.
+##
+## Derivation: the base R `Titanic` 4-way contingency table, expanded to one row
+## per passenger (Class, Sex, Age, Survived). The shipped
+## data/titanic.raw.rda is byte-frozen; this reconstructs the object and VERIFIES
+## it fingerprint-identical to the shipped one -- it never overwrites the .rda.
+
+source("data-raw/verify.R")   # counts_to_cases(), verify_against_shipped()
+
+rebuild <- counts_to_cases(Titanic)
+
+verify_against_shipped("titanic.raw", rebuild, exact = TRUE)

--- a/data-raw/verify.R
+++ b/data-raw/verify.R
@@ -1,0 +1,48 @@
+## Shared helper for the data-raw provenance scripts.
+##
+## The shipped data/*.rda files are BYTE-FROZEN (lessons and committed Quarto
+## freezes depend on the exact bytes). So the regeneration scripts VERIFY a
+## reconstruction against the shipped object and NEVER overwrite it -- do not
+## call usethis::use_data() from these scripts. Base R only.
+
+.structure <- function(x) {
+  list(class = class(x), dim = dim(x), names = names(x),
+       types = unname(vapply(x, function(col) class(col)[1], "")),
+       levels = lapply(x, function(col) if (is.factor(col)) levels(col) else NULL))
+}
+
+## Compare a reconstruction to the SHIPPED dataset without touching data/*.rda.
+## exact = TRUE  -> the reconstruction must be identical() to the shipped object
+##                  (values, order and structure; identical() ignores the order
+##                  of attributes, so it is the right "same data" test here).
+## exact = FALSE -> only the structure (class/dims/names/types/levels) must match.
+verify_against_shipped <- function(name, rebuild, exact = TRUE) {
+  ## Load the SHIPPED object directly from the source tree (data-raw scripts run
+  ## from the package root); this does not require datarium to be installed.
+  rda <- file.path("data", paste0(name, ".rda"))
+  if (!file.exists(rda)) stop("run from the package root; missing ", rda, call. = FALSE)
+  e <- new.env()
+  load(rda, envir = e)
+  shipped <- get(ls(e)[1], envir = e)
+  structural  <- identical(.structure(shipped), .structure(rebuild))
+  exact_match <- isTRUE(identical(shipped, rebuild))
+  cat(sprintf("%-16s structure: %-8s exact (identical): %s\n", name,
+              if (structural) "MATCH" else "MISMATCH",
+              if (exact_match) "MATCH" else "differ"))
+  if (exact && !exact_match)
+    stop(name, ": reconstruction is not identical() to the shipped object", call. = FALSE)
+  if (!exact && !structural)
+    stop(name, ": reconstruction structure does not match the shipped object", call. = FALSE)
+  invisible(exact_match)
+}
+
+## The contingency-table -> case-level helper (also shown in README.Rmd).
+counts_to_cases <- function(x, countcol = "Freq") {
+  if (!inherits(x, "table")) x <- as.table(as.matrix(x))
+  x <- as.data.frame(x)
+  idx <- rep.int(seq_len(nrow(x)), x[[countcol]])
+  x[[countcol]] <- NULL
+  x <- x[idx, ]
+  rownames(x) <- seq_len(nrow(x))
+  x
+}


### PR DESCRIPTION
Documents how the deterministic-derived datasets are built and **verifies** the reconstructions against the shipped byte-frozen objects, **without overwriting** them. `data-raw` is `.Rbuildignore`d, so this does not ship to CRAN and adds **no package dependency** (DESCRIPTION unchanged).

- `verify.R`: shared fingerprint verifier (structure + optional row-exact value hash), loads the shipped object from `data/*.rda`; never calls `use_data()`.
- `titanic.raw.R`: base R `Titanic` -> cases; verified fingerprint-identical.
- `AirPassengersDf.R`: rewritten to base R (was zoo/readr) and to verify instead of `usethis::use_data(overwrite = TRUE)` (which would have changed the frozen bytes); verified fingerprint-identical.
- `housetasks.raw.R`: factoextra `housetasks` (Wife/Husband relabeled), expanded to cases; structurally verified (the shipped case *order* is the source of truth).
- `README.md`: documents the deterministic / contingency / stochastic split.

Verified locally: all three scripts run and verify correctly; `data/` byte-identical after running them (no overwrite); `data-raw` excluded from the built tarball (0 entries); package still `R CMD check` clean.